### PR TITLE
Add water layer to color picker

### DIFF
--- a/example-x.html
+++ b/example-x.html
@@ -33,21 +33,40 @@
       .initMap({ container: "#map" })
       .then((map) => {
 
-        // AColorPicker.from( '#color-picker' ).on( 'change', ( picker, color ) => {
-        //   const rgb = AColorPicker.parseColor( color, "rgb" );
-        //   const waterColor = rgb.map( value => value * 0.7 )
-        //   const buildingColor = rgb.map( value => value * 1.2 )
-        //   map.setPaintProperty( 'background', 'background-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-        //   map.setPaintProperty( 'Land', 'fill-color', AColorPicker.parseColor( color, "rgbcss" ) );
-        //   map.setPaintProperty( 'Urban area', 'fill-color', AColorPicker.parseColor( color, "rgbcss" ) );
-        //   map.setPaintProperty( 'Building', 'fill-color', AColorPicker.parseColor( buildingColor, "rgbcss" ) );
-        //   map.setPaintProperty( 'Water area medium scale/Lake or river', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-        //   map.setPaintProperty( 'Water area large scale/Lake or river', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-        //   map.setPaintProperty( 'Water area/Lake, river or bay', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-        //   map.setPaintProperty( 'Water line medium scale', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-        //   map.setPaintProperty( 'Water line large scale', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-        //   map.setPaintProperty( 'Water line/Waterfall', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-        // } )
+        AColorPicker.from( '#color-picker' ).on( 'change', ( picker, color ) => {
+          const rgb = AColorPicker.parseColor( color, "rgb" );
+          const waterColor = rgb.map( value => value * 0.7 )
+          const buildingColor = rgb.map( value => value * 1.2 )
+          // map.setPaintProperty( 'background', 'background-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          // map.setPaintProperty( 'Land', 'fill-color', AColorPicker.parseColor( color, "rgbcss" ) );
+          // map.setPaintProperty( 'Urban area', 'fill-color', AColorPicker.parseColor( color, "rgbcss" ) );
+          // map.setPaintProperty( 'Building', 'fill-color', AColorPicker.parseColor( buildingColor, "rgbcss" ) );
+
+          // Sea Layer
+          map.setPaintProperty( 'Marine area/1', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Bathymetry/depth 2 (shallow water)', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Bathymetry/depth 3', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Bathymetry/depth 4', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Bathymetry/depth 5', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Bathymetry/depth 6', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Bathymetry/depth 7 (deep water)', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Coastline', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+
+          // Water Area and Line Layer
+          map.setPaintProperty( 'Water area small scale', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Water area small scale', 'fill-outline-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Water area medium scale/Lake or river', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Water area medium scale/Lake or river', 'fill-outline-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Water area large scale/Lake or river', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Water area large scale/Lake or river', 'fill-outline-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Water area/Lake, river or bay', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Water area/Lake, river or bay', 'fill-outline-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Water line small scale', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Water line medium scale', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Water line large scale', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Water line/Waterfall', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Water line/Stream or river', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+        } )
 
       })
 

--- a/example-x.html
+++ b/example-x.html
@@ -36,7 +36,7 @@
         AColorPicker.from( '#color-picker' ).on( 'change', ( picker, color ) => {
           const rgb = AColorPicker.parseColor( color, "rgb" );
           const waterColor = rgb.map( value => value * 0.7 )
-          const buildingColor = rgb.map( value => value * 1.2 )
+          // const buildingColor = rgb.map( value => value * 1.2 )
           // map.setPaintProperty( 'background', 'background-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
           // map.setPaintProperty( 'Land', 'fill-color', AColorPicker.parseColor( color, "rgbcss" ) );
           // map.setPaintProperty( 'Urban area', 'fill-color', AColorPicker.parseColor( color, "rgbcss" ) );
@@ -65,7 +65,6 @@
           map.setPaintProperty( 'Bathymetry/depth 6', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
           map.setPaintProperty( 'Bathymetry/depth 7 (deep water)', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
           map.setPaintProperty( 'Coastline', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-
         } )
 
       })

--- a/example-x.html
+++ b/example-x.html
@@ -42,17 +42,6 @@
           // map.setPaintProperty( 'Urban area', 'fill-color', AColorPicker.parseColor( color, "rgbcss" ) );
           // map.setPaintProperty( 'Building', 'fill-color', AColorPicker.parseColor( buildingColor, "rgbcss" ) );
 
-          // Sea Layer
-          map.setPaintProperty( 'Marine area/1', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-          map.setPaintProperty( 'Bathymetry/depth 2 (shallow water)', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-          map.setPaintProperty( 'Bathymetry/depth 3', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-          map.setPaintProperty( 'Bathymetry/depth 4', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-          map.setPaintProperty( 'Bathymetry/depth 5', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-          map.setPaintProperty( 'Bathymetry/depth 6', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-          map.setPaintProperty( 'Bathymetry/depth 7 (deep water)', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-          map.setPaintProperty( 'Coastline', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
-
-          // Water Area and Line Layer
           map.setPaintProperty( 'Water area small scale', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
           map.setPaintProperty( 'Water area small scale', 'fill-outline-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
           map.setPaintProperty( 'Water area medium scale/Lake or river', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
@@ -66,6 +55,17 @@
           map.setPaintProperty( 'Water line large scale', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
           map.setPaintProperty( 'Water line/Waterfall', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
           map.setPaintProperty( 'Water line/Stream or river', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+
+          // Sea Layer
+          map.setPaintProperty( 'Marine area/1', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Bathymetry/depth 2 (shallow water)', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Bathymetry/depth 3', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Bathymetry/depth 4', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Bathymetry/depth 5', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Bathymetry/depth 6', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Bathymetry/depth 7 (deep water)', 'fill-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+          map.setPaintProperty( 'Coastline', 'line-color', AColorPicker.parseColor( waterColor, "rgbcss" ) );
+
         } )
 
       })


### PR DESCRIPTION
`Esri Light`スタイルの水に関するレイヤーの色を変更できるように、レイヤーIDを`map.setPaintProperty`に追加しました。

過去に `map.setPaintProperty`で追加してあったレイヤーIDは削除せず、新規にレイヤーIDを追加しました。

## 低ズーム
<img width="1438" alt="スクリーンショット 2021-06-01 12 18 33" src="https://user-images.githubusercontent.com/8760841/120262132-40be4a00-c2d4-11eb-8ab7-b3de39c695dc.png">

## 高ズーム
<img width="1440" alt="スクリーンショット 2021-06-01 12 19 02" src="https://user-images.githubusercontent.com/8760841/120262140-4320a400-c2d4-11eb-8297-fda7b16fabe5.png">
